### PR TITLE
Add User-Agent to request headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ function crawl(url, done) {
       url: url,
       encoding: null,
       headers: {
-        'Accept-Language': 'en-US,en;q=0.8,fi;q=0.6'
+        'Accept-Language': 'en-US,en;q=0.8,fi;q=0.6',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36'
       }
     })
     .on('error', reject)

--- a/test/index.js
+++ b/test/index.js
@@ -65,4 +65,11 @@ describe('Title scraper', function() {
     .catch(done.bind(null, null));
   });
 
+  it('should make requests with an user agent header set', function(done) {
+    title(u('user-agent'))
+    .then(function(title) {
+      assert.equal(title, 'bar');
+      done();
+    });
+  });
 });

--- a/test/mock-server/index.js
+++ b/test/mock-server/index.js
@@ -28,6 +28,17 @@ app.get('/image', function(req, res) {
   res.sendfile(path.join(__dirname, 'files', 'image.jpg'));
 });
 
+app.get('/user-agent', function(req, res) {
+  var userAgent = req.get('User-Agent');
+  var title = '<title>Update your browser</title>';
+
+  if(userAgent !== undefined && userAgent.length > 0) {
+    title = '<title>bar</title>';
+  }
+
+  res.send(title);
+});
+
 if(require.main === module) {
   app.listen(9005);
 }


### PR DESCRIPTION
Some sites don't play nice when there's no User-Agent header provided with the request (for example, Facebook advices you to update your browser instead of serving the correct content).
